### PR TITLE
added PKGBUILD

### DIFF
--- a/libhttpseverywhere-git/PKGBUILD
+++ b/libhttpseverywhere-git/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Lukas Epple <post@lukasepple.de>
+
+_pkgname=libhttpseverywhere
+pkgname="$_pkgname-git"
+pkgrel=1
+pkgdesc="the visual history browser"
+arch=('i686' 'x86_64')
+url="https://github.com/grindhold/libhttpseverywhere/"
+license=('LGPL3')
+depends=('libgee' ':ibxml2')
+makedepends=('git' 'cmake' 'make' 'vala' 'valadoc-git' 'gobject-introspection')
+conflicts=('libhttpseverywhere')
+provides=('libhttpseverywhere')
+source=(git+git://github.com/grindhold/libhttpseverywhere.git)
+md5sums=(SKIP)
+
+pkgver() {
+  cd "$srcdir/$_pkgname"
+  echo "$(git rev-list --count HEAD)+g$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd "$srcdir/$_pkgname"
+  cmake -DCMAKE_INSTALL_PREFIX="$pkgdir/usr"
+  make
+}
+
+package() {
+  cd "$srcdir/$_pkgname"
+  make install
+}


### PR DESCRIPTION
build works fine. Maybe there are some problems with it. They will
become appearant once rainbow-lollipop depends on libhttpseverywhere