### PR TITLE
Cancellable

### DIFF
--- a/src/context.vala
+++ b/src/context.vala
@@ -88,7 +88,7 @@ namespace HTTPSEverywhere {
          * This function initializes HTTPSEverywhere by loading
          * the rulesets from the filesystem.
          */
-        public async void init() {
+        public async void init(Cancellable? cancellable = null) throws IOError {
             initialized = false;
 
             targets = new Gee.HashMap<Target,Gee.ArrayList<uint>>();
@@ -109,8 +109,14 @@ namespace HTTPSEverywhere {
                 try {
                     File f = File.new_for_path(dp);
                     DataInputStream dis = new DataInputStream(f.read());
-                    yield parser.load_from_stream_async(dis);
-                } catch(GLib.Error e) { continue; }
+                    yield parser.load_from_stream_async(dis, cancellable);
+                } catch (Error e) {
+                    if (e is IOError.CANCELLED) {
+                        execute_init_complete_callbacks();
+                        throw (IOError) e;
+                    }
+                    continue;
+                }
                 success = true;
                 break;
             }

--- a/src/context.vala
+++ b/src/context.vala
@@ -108,7 +108,8 @@ namespace HTTPSEverywhere {
             foreach (string dp in datapaths) {
                 try {
                     File f = File.new_for_path(dp);
-                    DataInputStream dis = new DataInputStream(f.read());
+                    FileInputStream fis = yield f.read_async(Priority.DEFAULT, cancellable);
+                    DataInputStream dis = new DataInputStream(fis);
                     yield parser.load_from_stream_async(dis, cancellable);
                 } catch (Error e) {
                     if (e is IOError.CANCELLED) {

--- a/test/main.vala
+++ b/test/main.vala
@@ -88,6 +88,26 @@ namespace HTTPSEverywhereTest {
                 loop.run();
                 assert(count == 2);
             });
+
+            Test.add_func("/httpseverywhere/context/cancel_init", () => {
+                var loop = new MainLoop();
+                var context = new Context();
+                var cancellable = new Cancellable();
+
+                context.init.begin(cancellable, (obj, res) => {
+                    try {
+                        context.init.end(res);
+                        assert_not_reached();
+                    } catch (Error e) {
+                        assert(e is IOError.CANCELLED);
+                        assert(cancellable.is_cancelled());
+                        loop.quit();
+                    }
+                });
+
+                cancellable.cancel();
+                loop.run();
+            });
         }
     }
 


### PR DESCRIPTION
Epiphany will want to cancel all pending operations when the web extension is destroyed. In general, any async operation should be cancellable.

I'm having a lot of trouble with making rewrite() cancellable; that will have to come in a follow-up.